### PR TITLE
Quick fix for missing data

### DIFF
--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -17,13 +17,8 @@ class WelcomeController extends Controller
 
    
     public function article($slug){
-
-
     	$post = Post::findBySlug($slug);
-
-
-    	return view('article');
-    	with('post', $post);
+    	return view('article')->with('post', $post);
     }
 
    


### PR DESCRIPTION
Removing a semicolon that ends the return statement before sending the post variable to the view.

You can also use compact

`return view('article', compact('post'));`

or the array method

`return view('article', ['post' => $post]);`

I hope this will help you.